### PR TITLE
Add GitHub action for rebasing release branches

### DIFF
--- a/.github/workflows/rebase-release-branches.yml
+++ b/.github/workflows/rebase-release-branches.yml
@@ -1,0 +1,40 @@
+name: Rebase Release Branches
+
+# Controls when the action will run.
+on:
+  push:
+    branches: [ master ]
+
+  # Allows running this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  rebase-release-branches:
+    if: github.event.comment.author_association == 'MEMBER'
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: rebase dunfell
+        uses: iris-GmbH/gh-action-rebase@1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REBASE_BRANCH: dunfell
+          BASE_BRANCH: master
+
+      - name: rebase gatesgarth
+        uses: iris-GmbH/gh-action-rebase@1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REBASE_BRANCH: gatesgarth
+          BASE_BRANCH: master
+
+      - name: rebase hardknott
+        uses: iris-GmbH/gh-action-rebase@1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REBASE_BRANCH: hardknott
+          BASE_BRANCH: master


### PR DESCRIPTION
OpenEmbedded layers use separate branches for the Yocto releases. This
is neat, as it allows for recipe changes specific to a Yocto release.
However, manually maintaining these branches is annoying.

This commit adds a GitHub Action which automatically tries to rebase the
Yocto release branches on the master branch after push to the latter.