### PR TITLE
Update patch upstream metadata

### DIFF
--- a/recipes-core/caf/caf-0.18.3/0001-Fix-CMakeLists.txt-for-installing-caf-tools.patch
+++ b/recipes-core/caf/caf-0.18.3/0001-Fix-CMakeLists.txt-for-installing-caf-tools.patch
@@ -7,7 +7,7 @@ This change fixes the outcome of `make install`, which previously would
 install the tools' .cpp files to `/usr/local/share/caf/tools`. Now, we
 install the built tool binaries instead.
 
-Upstream-Status: Merged: https://github.com/actor-framework/actor-framework/pull/1267
+Upstream-Status: Accepted [https://github.com/actor-framework/actor-framework/pull/1267]
 ---
  tools/CMakeLists.txt | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/recipes-core/mongoose/mongoose-7.2/0001-Add-static-and-dynamic-lib-targets-to-Makefile.patch
+++ b/recipes-core/mongoose/mongoose-7.2/0001-Add-static-and-dynamic-lib-targets-to-Makefile.patch
@@ -3,6 +3,7 @@ From: Jasper Orschulko <Jasper.Orschulko@iris-sensing.com>
 Date: Wed, 2 Jun 2021 02:09:55 +0200
 Subject: [PATCH] Add static and dynamic lib targets to Makefile
 
+Upstream-Status: Submitted [https://github.com/cesanta/mongoose/pull/1295]
 ---
  Makefile | 41 ++++++++++++++++++++++++++++++++++++++++-
  1 file changed, 39 insertions(+), 0 deletion(-)

--- a/recipes-core/quirc/quirc-1.1/0001-Set-Makefiles-LIB_VERSION-to-1.1.patch
+++ b/recipes-core/quirc/quirc-1.1/0001-Set-Makefiles-LIB_VERSION-to-1.1.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Set Makefiles LIB_VERSION to 1.1
 LIB_VERSION in Makefile is now correctly set to match the release,
 resulting in correctly versioned dynamic library
 
-Upstream-Status: Inappropriate
+Upstream-Status: Inappropriate configuration
 ---
  Makefile | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/recipes-core/seasocks/seasocks-1.4.4/0001-versioned-shared-library.patch
+++ b/recipes-core/seasocks/seasocks-1.4.4/0001-versioned-shared-library.patch
@@ -17,7 +17,7 @@ after:
 Co-authored-by: offa <bm-dev@yandex.com>
 Co-authored-by: Anonymous Maarten <madebr@users.noreply.github.com>
 
-Upstream-Status: Merged [https://github.com/mattgodbolt/seasocks/pull/153]
+Upstream-Status: Accepted [https://github.com/mattgodbolt/seasocks/pull/153]
 ---
  src/main/c/CMakeLists.txt | 7 +++++++
  1 file changed, 7 insertions(+)


### PR DESCRIPTION
The patch metadata now contains the correct information in accordance
with
[https://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines#Patch_Header_Recommendations:_Upstream-Status]