### PR TITLE
caf: Bump default version to 0.18.4

### DIFF
--- a/recipes-core/caf/caf_0.18.3.bb
+++ b/recipes-core/caf/caf_0.18.3.bb
@@ -6,3 +6,5 @@ require recipes-core/caf/caf.inc
 SRCREV = "728f6d82f451c037931e53701f8d8b9a900f36eb"
 
 SRC_URI += "file://0001-Fix-CMakeLists.txt-for-installing-caf-tools.patch"
+
+DEFAULT_PREFERENCE = "-1"

--- a/recipes-core/caf/caf_0.18.4.bb
+++ b/recipes-core/caf/caf_0.18.4.bb
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2021 iris-GmbH infrared & intelligent sensors
+
+require recipes-core/caf/caf.inc
+
+SRCREV = "d25d4f998c4be627f39bb98f99dcfb3b88b9f877"


### PR DESCRIPTION
- add recipe for caf version 0.18.4
- set default preference for caf version 0.18.3 to "-1"