### PR TITLE
mongoose: version bump to 7.4

### DIFF
--- a/recipes-core/mongoose/mongoose.inc
+++ b/recipes-core/mongoose/mongoose.inc
@@ -9,7 +9,6 @@ HOMEPAGE = "https://www.cesanta.com/"
 
 LICENSE = "GPLv2 | mongoose"
 LICENSE_FLAGS = "commercial"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=530df01565982e978c1e24a2ee516eeb"
 
 SECTION = "libs"
 

--- a/recipes-core/mongoose/mongoose_7.2.bb
+++ b/recipes-core/mongoose/mongoose_7.2.bb
@@ -4,6 +4,7 @@
 require recipes-core/mongoose/mongoose.inc
 
 SRCREV = "452bcc68a4c5fecce2ca6ad5c9b60beca9b0214f"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=530df01565982e978c1e24a2ee516eeb"
 
 SRC_URI += "file://0001-Makefile-add-static-and-dynamic-lib-targets.patch"
 

--- a/recipes-core/mongoose/mongoose_7.3.bb
+++ b/recipes-core/mongoose/mongoose_7.3.bb
@@ -4,5 +4,8 @@
 require recipes-core/mongoose/mongoose.inc
 
 SRCREV = "32406b678b43de139403e6ad68de26a50d38a1c1"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=530df01565982e978c1e24a2ee516eeb"
 
 EXTRA_OEMAKE += "'SOVERSION=7.3'" 
+
+DEFAULT_PREFERENCE = "-1"

--- a/recipes-core/mongoose/mongoose_7.4.bb
+++ b/recipes-core/mongoose/mongoose_7.4.bb
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2021 iris-GmbH infrared & intelligent sensors
+
+require recipes-core/mongoose/mongoose.inc
+
+SRCREV = "f08d2804292647f4c738ffaa4d9e4168114aa731"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=9cd42b5f2ca072e034ac9b6706aaffe7"
+
+EXTRA_OEMAKE += "'SOVERSION=7.4'" 


### PR DESCRIPTION
For release details please visit https://github.com/cesanta/mongoose/releases/tag/7.4