### PR TITLE
Add native and nativesdk to bbclassextend

### DIFF
--- a/recipes-core/caf/caf.inc
+++ b/recipes-core/caf/caf.inc
@@ -30,3 +30,5 @@ EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=RELEASE \
                   -DCAF_ENABLE_EXAMPLES=OFF \
                   -DCAF_ENABLE_TESTING=OFF \
                   -DCMAKE_CXX_STANDARD=17"
+
+BBCLASSEXTEND =+ "native nativesdk"

--- a/recipes-core/dlib/dlib_19.22.bb
+++ b/recipes-core/dlib/dlib_19.22.bb
@@ -19,3 +19,5 @@ EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=RELEASE"
 
 # build as shared library
 EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=TRUE"
+
+BBCLASSEXTEND =+ "native nativesdk"

--- a/recipes-core/mongoose/mongoose.inc
+++ b/recipes-core/mongoose/mongoose.inc
@@ -30,3 +30,5 @@ do_install(){
     mkdir -p ${D}${includedir}
     oe_runmake install
 }
+
+BBCLASSEXTEND =+ "native nativesdk"

--- a/recipes-core/quirc/quirc_1.1.bb
+++ b/recipes-core/quirc/quirc_1.1.bb
@@ -39,3 +39,4 @@ do_install () {
     oe_runmake install DESTDIR=${D}
 }
 
+BBCLASSEXTEND =+ "native nativesdk"

--- a/recipes-core/seasocks/seasocks_1.4.4.bb
+++ b/recipes-core/seasocks/seasocks_1.4.4.bb
@@ -35,3 +35,5 @@ do_install_append() {
     rmdir ${D}${datadir}/licenses 2>/dev/null || true
     rmdir ${D}${datadir} 2>/dev/null || true
 }
+
+BBCLASSEXTEND =+ "native nativesdk"


### PR DESCRIPTION
Allows for building software for the host system, as well as for the
SDK.