### PR TITLE
[APC-5918] Use new override syntax and add support for kirkstone

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,6 +12,6 @@ BBFILE_PRIORITY_iris-thirdparty = "6"
 LAYERDEPENDS_iris-thirdparty = "core \
                                 openembedded-layer"
 
-LAYERSERIES_COMPAT_iris-thirdparty = "dunfell gatesgarth hardknott"
+LAYERSERIES_COMPAT_iris-thirdparty = "dunfell gatesgarth hardknott kirkstone"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"

--- a/recipes-core/argon2/argon2_20190702.bb
+++ b/recipes-core/argon2/argon2_20190702.bb
@@ -28,6 +28,6 @@ do_install () {
 }
 
 PACKAGES =+ "${PN}-bin"
-FILES_${PN}-bin = "${bindir}/*"
+FILES:${PN}-bin = "${bindir}/*"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-core/caf/caf.inc
+++ b/recipes-core/caf/caf.inc
@@ -16,11 +16,11 @@ DEPENDS = "curl openssl"
 
 PACKAGES =+ "${PN}-openssl ${PN}-io ${PN}-tools"
 
-FILES_${PN}-openssl += "${libdir}/libcaf_openssl.so.${PV}" 
-FILES_${PN}-io += "${libdir}/libcaf_io.so.${PV}" 
-FILES_${PN}-tools += "${datadir}/caf/tools/*" 
+FILES:${PN}-openssl += "${libdir}/libcaf_openssl.so.${PV}"
+FILES:${PN}-io += "${libdir}/libcaf_io.so.${PV}"
+FILES:${PN}-tools += "${datadir}/caf/tools/*"
 
-RDEPENDS_${PN}-openssl = "openssl"
+RDEPENDS:${PN}-openssl = "openssl"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-core/mongoose/mongoose.inc
+++ b/recipes-core/mongoose/mongoose.inc
@@ -17,7 +17,7 @@ SRC_URI += "file://Findmongoose.cmake"
 
 S = "${WORKDIR}/git"
 
-CFLAGS_prepend = "-Wno-format-truncation -fPIC "
+CFLAGS:prepend = "-Wno-format-truncation -fPIC "
 EXTRA_OEMAKE = "'CC=${CC}' 'AR=${AR}' 'CFLAGS=${CFLAGS}' 'DESTDIR=${D}' 'PREFIX=/usr'"
 
 do_compile(){

--- a/recipes-core/quirc/quirc_1.1.bb
+++ b/recipes-core/quirc/quirc_1.1.bb
@@ -24,12 +24,12 @@ S = "${WORKDIR}/git"
 DEPENDS = "libsdl libsdl-gfx libjpeg-turbo libpng"
 
 PACKAGES =+ "${PN}-scanner ${PN}-demo"
-FILES_${PN}-scanner = "${bindir}/${PN}-scanner"
-FILES_${PN}-demo = "${bindir}/${PN}-demo"
+FILES:${PN}-scanner = "${bindir}/${PN}-scanner"
+FILES:${PN}-demo = "${bindir}/${PN}-demo"
 
 inherit pkgconfig
 
-CFLAGS_prepend = "-fPIC "
+CFLAGS:prepend = "-fPIC "
 EXTRA_OEMAKE = "'PREFIX=/usr/'"
 
 do_compile () {

--- a/recipes-core/seasocks/seasocks_1.4.4.bb
+++ b/recipes-core/seasocks/seasocks_1.4.4.bb
@@ -35,7 +35,7 @@ EXTRA_OECMAKE += "-DSEASOCKS_SHARED=TRUE"
 
 # remove license from base-package installation process.
 # yocto has it's own workflow for license inclusion
-do_install_append() {
+do_install:append() {
     rm -r  ${D}${datadir}/licenses/Seasocks
     rmdir ${D}${datadir}/licenses 2>/dev/null || true
     rmdir ${D}${datadir} 2>/dev/null || true

--- a/recipes-devtools/cmake/cmake_%.bbappend
+++ b/recipes-devtools/cmake/cmake_%.bbappend
@@ -1,8 +1,8 @@
 SRC_URI += "file://iristhirdparty-modules.cmake"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-do_install_append_class-nativesdk() {
+do_install:append:class-nativesdk() {
     # OEToolchainConfig.cmake will include everything in OEToolchainConfig.cmake.d/
     mkdir -p ${D}${datadir}/cmake/OEToolchainConfig.cmake.d/
     install -m 644 ${WORKDIR}/iristhirdparty-modules.cmake ${D}${datadir}/cmake/OEToolchainConfig.cmake.d/


### PR DESCRIPTION
"kirkstone" is a newly created branch, currently pointing to "dunfell".

This PR contains changes so the kirkstone branch is actually usable with kirkstone.