### PR TITLE
yaml-cpp: Backport patch to fix cmake export files

### DIFF
--- a/recipes-support/yaml-cpp/yaml-cpp-0.7.0/0001-Fix-CMake-export-files-1077.patch
+++ b/recipes-support/yaml-cpp/yaml-cpp-0.7.0/0001-Fix-CMake-export-files-1077.patch
@@ -1,0 +1,113 @@
+From 3d436f6cfc2dfe52fc1533c01f57c25ae7ffac9c Mon Sep 17 00:00:00 2001
+From: Felix Schwitzer <flx107809@gmail.com>
+Date: Fri, 1 Apr 2022 05:26:47 +0200
+Subject: [PATCH] Fix CMake export files (#1077)
+
+After configuring the file `yaml-cpp-config.cmake.in`, the result ends up with
+empty variables.  (see also the discussion in #774).
+
+Rework this file and the call to `configure_package_config_file` according the
+cmake documentation
+(https://cmake.org/cmake/help/v3.22/module/CMakePackageConfigHelpers.html?highlight=configure_package_config#command:configure_package_config_file)
+to overcome this issue and allow a simple `find_package` after install.
+
+As there was some discussion about the place where to install the
+`yaml-cpp-config.cmake` file, e.g. #1055, factor out the install location into
+an extra variable to make it easier changing this location in the future.
+
+Also untabify CMakeLists.txt in some places to align with the other code parts in this file.
+---
+ CMakeLists.txt           | 29 ++++++++++++++++++-----------
+ yaml-cpp-config.cmake.in | 10 ++++++----
+ 2 files changed, 24 insertions(+), 15 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b230b9e..983d1a4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -127,10 +127,16 @@ set_target_properties(yaml-cpp PROPERTIES
+   PROJECT_LABEL "yaml-cpp ${yaml-cpp-label-postfix}"
+   DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
+ 
++# FIXME(felix2012): A more common place for the cmake export would be
++# `CMAKE_INSTALL_LIBDIR`, as e.g. done in ubuntu or in this project for GTest
++set(CONFIG_EXPORT_DIR "${CMAKE_INSTALL_DATADIR}/cmake/yaml-cpp")
++set(EXPORT_TARGETS yaml-cpp)
+ configure_package_config_file(
+   "${PROJECT_SOURCE_DIR}/yaml-cpp-config.cmake.in"
+   "${PROJECT_BINARY_DIR}/yaml-cpp-config.cmake"
+-  INSTALL_DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/yaml-cpp")
++  INSTALL_DESTINATION "${CONFIG_EXPORT_DIR}"
++  PATH_VARS CMAKE_INSTALL_INCLUDEDIR CONFIG_EXPORT_DIR)
++unset(EXPORT_TARGETS)
+ 
+ write_basic_package_version_file(
+   "${PROJECT_BINARY_DIR}/yaml-cpp-config-version.cmake"
+@@ -139,30 +145,31 @@ write_basic_package_version_file(
+ configure_file(yaml-cpp.pc.in yaml-cpp.pc @ONLY)
+ 
+ if (YAML_CPP_INSTALL)
+-	install(TARGETS yaml-cpp
++  install(TARGETS yaml-cpp
+     EXPORT yaml-cpp-targets
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-	install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
++  install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
+     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+-		FILES_MATCHING PATTERN "*.h")
++                FILES_MATCHING PATTERN "*.h")
+   install(EXPORT yaml-cpp-targets
+-    DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/yaml-cpp")
+-	install(FILES
+-		"${PROJECT_BINARY_DIR}/yaml-cpp-config.cmake"
+-		"${PROJECT_BINARY_DIR}/yaml-cpp-config-version.cmake"
+-    DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/yaml-cpp")
++    DESTINATION "${CONFIG_EXPORT_DIR}")
++  install(FILES
++      "${PROJECT_BINARY_DIR}/yaml-cpp-config.cmake"
++      "${PROJECT_BINARY_DIR}/yaml-cpp-config-version.cmake"
++    DESTINATION "${CONFIG_EXPORT_DIR}")
+   install(FILES "${PROJECT_BINARY_DIR}/yaml-cpp.pc"
+     DESTINATION ${CMAKE_INSTALL_DATADIR}/pkgconfig)
+ endif()
++unset(CONFIG_EXPORT_DIR)
+ 
+ if(YAML_CPP_BUILD_TESTS)
+-	add_subdirectory(test)
++  add_subdirectory(test)
+ endif()
+ 
+ if(YAML_CPP_BUILD_TOOLS)
+-	add_subdirectory(util)
++  add_subdirectory(util)
+ endif()
+ 
+ if (YAML_CPP_CLANG_FORMAT_EXE)
+diff --git a/yaml-cpp-config.cmake.in b/yaml-cpp-config.cmake.in
+index 7b41e3f..a7ace3d 100644
+--- a/yaml-cpp-config.cmake.in
++++ b/yaml-cpp-config.cmake.in
+@@ -3,12 +3,14 @@
+ #  YAML_CPP_INCLUDE_DIR - include directory
+ #  YAML_CPP_LIBRARIES    - libraries to link against
+ 
+-# Compute paths
+-get_filename_component(YAML_CPP_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+-set(YAML_CPP_INCLUDE_DIR "@CONFIG_INCLUDE_DIRS@")
++@PACKAGE_INIT@
++
++set_and_check(YAML_CPP_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+ 
+ # Our library dependencies (contains definitions for IMPORTED targets)
+-include("${YAML_CPP_CMAKE_DIR}/yaml-cpp-targets.cmake")
++include(@PACKAGE_CONFIG_EXPORT_DIR@/yaml-cpp-targets.cmake)
+ 
+ # These are IMPORTED targets created by yaml-cpp-targets.cmake
+ set(YAML_CPP_LIBRARIES "@EXPORT_TARGETS@")
++
++check_required_components(@EXPORT_TARGETS@)
+-- 
+2.39.2
+

--- a/recipes-support/yaml-cpp/yaml-cpp_0.7.0.bbappend
+++ b/recipes-support/yaml-cpp/yaml-cpp_0.7.0.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}-${PV}:"
+
+SRC_URI += "\
+	file://0001-Fix-CMake-export-files-1077.patch \
+"


### PR DESCRIPTION
This is only needed for kirkstone (and langdale). Only those versions of meta-oe come with yaml-cpp 0.7.0 which is the only version that needs this fix.

See: https://layers.openembedded.org/layerindex/recipe/163426/

Fix is take from: https://github.com/jbeder/yaml-cpp/commit/4aad2b1666a4742743b04e765a34742512915674