### PR TITLE
mongoose 7.17

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,6 +12,6 @@ BBFILE_PRIORITY_iris-thirdparty = "6"
 LAYERDEPENDS_iris-thirdparty = "core \
                                 openembedded-layer"
 
-LAYERSERIES_COMPAT_iris-thirdparty = "dunfell gatesgarth hardknott kirkstone mickledore"
+LAYERSERIES_COMPAT_iris-thirdparty = "dunfell gatesgarth hardknott kirkstone mickledore scarthgap"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"

--- a/recipes-core/mongoose/mongoose_7.17.bb
+++ b/recipes-core/mongoose/mongoose_7.17.bb
@@ -1,12 +1,10 @@
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2024 iris-GmbH infrared & intelligent sensors
+# Copyright (C) 2025 iris-GmbH infrared & intelligent sensors
 
 require recipes-core/mongoose/mongoose.inc
 
-SRCREV = "6bb40e6ec96f95bfd36a816b430ea2726fac9d05"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=801edb9e029931905c8413f0ae9c406b"
+SRCREV = "0a86bc0af22173b8c952c11551a067fd6f843d83"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1652935c3807a36cf17125a4a217dbc2"
 
 # Makefile was moved to test/Makefile with https://github.com/cesanta/mongoose/commit/89aaf1c30c20db939154121d4eb0320339b2f053
 MAKEFILE_DIR="test"
-
-DEFAULT_PREFERENCE = "-1"


### PR DESCRIPTION
Please backport for scarthgap and kirkstone
CI: https://gitlab.devops.defra01.iris-sensing.net/public-projects/yocto/iris-kas/-/pipelines/69287