### PR TITLE
mongoose: Bump version 7.18

### DIFF
--- a/recipes-core/mongoose/mongoose_7.18.bb
+++ b/recipes-core/mongoose/mongoose_7.18.bb
@@ -3,10 +3,8 @@
 
 require recipes-core/mongoose/mongoose.inc
 
-SRCREV = "0a86bc0af22173b8c952c11551a067fd6f843d83"
+SRCREV = "ccfe7e0724dd9bd4a6c447c84552e0ca47767ce8"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1652935c3807a36cf17125a4a217dbc2"
 
 # Makefile was moved to test/Makefile with https://github.com/cesanta/mongoose/commit/89aaf1c30c20db939154121d4eb0320339b2f053
 MAKEFILE_DIR="test"
-
-DEFAULT_PREFERENCE = "-1"


### PR DESCRIPTION
Please also backport to scarthgap and kirkstone