### PR TITLE
mongoose: Bump version 7.20

### DIFF
--- a/recipes-core/mongoose/mongoose_7.19.bb
+++ b/recipes-core/mongoose/mongoose_7.19.bb
@@ -5,3 +5,5 @@ require recipes-core/mongoose/mongoose.inc
 
 SRCREV = "739d78a45a8fa6595498df67d11cac3e39af8c0e"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1652935c3807a36cf17125a4a217dbc2"
+
+DEFAULT_PREFERENCE = "-1"

--- a/recipes-core/mongoose/mongoose_7.20.bb
+++ b/recipes-core/mongoose/mongoose_7.20.bb
@@ -3,7 +3,5 @@
 
 require recipes-core/mongoose/mongoose.inc
 
-SRCREV = "ccfe7e0724dd9bd4a6c447c84552e0ca47767ce8"
+SRCREV = "236724ea2948396b4f83b68c366a169e795aa7ef"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1652935c3807a36cf17125a4a217dbc2"
-
-DEFAULT_PREFERENCE = "-1"


### PR DESCRIPTION
Please backport to scarthgap + kirkstone as well