### PR TITLE
mongoose: Update v7.21 md5sum of LICENSE

### DIFF
--- a/recipes-core/mongoose/mongoose_7.21.bb
+++ b/recipes-core/mongoose/mongoose_7.21.bb
@@ -4,4 +4,4 @@
 require recipes-core/mongoose/mongoose.inc
 
 SRCREV = "b1c2ffe1a0aa13e3d94075b1a2c66b8b43ac9116"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=1652935c3807a36cf17125a4a217dbc2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=0ddcde673cf75f85dbdd2b3836c0d056"


### PR DESCRIPTION
Please backport to scarthgap/kirkstone